### PR TITLE
Update broken URLs to GitHub flow documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,13 +8,13 @@ We want your input! We want to make contributing to this manual as easy and tran
 - Proposing new content
 - Becoming a maintainer
 
-## We Develop with Github
+## We Develop with GitHub
 
 We use github to host code, to track issues and feature requests, as well as accept pull requests.
 
-## We Use [Github Flow](https://guides.github.com/introduction/flow/index.html), So All Code Changes Happen Through Pull Requests
+## We Use [GitHub Flow](https://docs.github.com/en/get-started/quickstart/github-flow), So All Code Changes Happen Through Pull Requests
 
-Pull requests are the best way to propose changes to the code (we use [Github Flow](https://guides.github.com/introduction/flow/index.html)). We actively welcome your pull requests:
+Pull requests are the best way to propose changes to the code (we use [GitHub Flow](https://docs.github.com/en/get-started/quickstart/github-flow)). We actively welcome your pull requests:
 
 Clone or Fork the repo (Fork it if you don't have write access)
 


### PR DESCRIPTION
## Issue Description 

Currently, links within the contributing guidelines to the GitHub flow documentation are broken; clicking either link redirects to the root of the documentation website at https://docs.github.com/en .

<img width="413" alt="image" src="https://user-images.githubusercontent.com/96429508/202181577-fef017e6-78b1-4154-a9f9-777d32c0aa73.png">


<!--
## Please fill in the sections below

After you submit your pull request, the Internal Services - Standards and Assurance team will discuss and prioritise it at our fortnightly triage meeting. 

We’ll then let you know if and when we’ll move it forward.
-->

## What’s changed

<!-- What are you trying to do or is it fixing a bug? -->

This PR amends the URL to a current version of the GitHub Flow documentation.

Additionally, I have updated the capitalisation of `Github` -> `GitHub`.

