### PR TITLE
Add a section about internal accessibility audits to tools

### DIFF
--- a/source/accessibility/tools.html.md.erb
+++ b/source/accessibility/tools.html.md.erb
@@ -12,7 +12,11 @@ review_in: 6 months
 
 # Tools and testing
 
-These tools and resources will help you uncover problems in services and websites. 
+These tools and resources will help you uncover problems in services and websites.
+
+## Internal audit template
+
+You should have your service audited by a professional accessibility auditor, like the internal DfE accessibility team, or the Digital Accessibility Centre (DAC). Before you send the application to them to review, you can find low-hanging fruit by going through an [internal audit using a template](https://gist.github.com/tvararu/8752e3ec5446bfafa9224db958b48e79).
 
 ## Colour tools
 


### PR DESCRIPTION
## What’s changed

This adds guidance for teams on how they can conduct a team-internal accessibility audit, and links to an example template.

## Identifying a user need

Users of the guidance should have tools and examples on how to conduct a team-internal accessibility audits

## Question/assumptions

- Should this paragraph link to a template that's on a separate service (GitHub gist), or should we copy and paste the template into this project and link to that?
- Is it okay to create a new section like I did, since the other two sections didn't seem to fit this?